### PR TITLE
Made specification of dependencies more general and removed redundant…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ option(FIBER_ENABLE_2DECOMP   "Enable the 2DECOMP backend"      OFF)
 option(FIBER_ENABLE_NB3DFFT   "Enable the NB3DFFT backend"      OFF)
 option(FIBER_ENABLE_FFTW      "Enable the FFTW backend"         OFF)
 
-set(FIBER_FFT_INCLUDE_DIR "" CACHE FILEPATH "Path to FFT library headers")
-set(FIBER_FFT_LIB_DIR "" CACHE FILEPATH "Path to FFT library files")
+set(FIBER_FFT_INCLUDE_DIRS "" CACHE FILEPATH "Path to FFT library headers")
+set(FIBER_FFT_LIB_DIRS "" CACHE FILEPATH "Path to FFT library files")
 
 set(CMAKE_C_FLAGS "-lm")
 
@@ -28,8 +28,8 @@ endif ()
 find_package(MPI REQUIRED)
 
 # Location of the FFT library
-include_directories(${FIBER_FFT_INCLUDE_DIR})
-link_directories(${FIBER_FFT_LIB_DIR})
+include_directories(${FIBER_FFT_INCLUDE_DIRS})
+link_directories(${FIBER_FFT_LIB_DIRS})
 
 # Location of FFTW
 include_directories(${FFTW_DIR}/include)
@@ -41,6 +41,8 @@ include_directories(include)
 # Location of MPI
 include_directories(${MPI_DIR}/include)
 link_directories(${MPI_DIR}/lib)
+
+add_definitions(-DFIBER_ENABLE_HEFFTE)
 
 if (FIBER_ENABLE_CUDA)
     find_package(CUDA REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ option(FIBER_ENABLE_2DECOMP   "Enable the 2DECOMP backend"      OFF)
 option(FIBER_ENABLE_NB3DFFT   "Enable the NB3DFFT backend"      OFF)
 option(FIBER_ENABLE_FFTW      "Enable the FFTW backend"         OFF)
 
+set(FIBER_FFT_INCLUDE_DIR "" CACHE FILEPATH "Path to FFT library headers")
+set(FIBER_FFT_LIB_DIR "" CACHE FILEPATH "Path to FFT library files")
+
 set(CMAKE_C_FLAGS "-lm")
 
 # FIBER uses C99 features (in-loop definition of for loop variables)
@@ -24,61 +27,20 @@ endif ()
 
 find_package(MPI REQUIRED)
 
-# Add include paths
-if (FIBER_ENABLE_HEFFTE)
-add_definitions(-DFIBER_ENABLE_HEFFTE)
-include_directories($ENV{HOME}/heffte/build/include)
-link_directories($ENV{HOME}/heffte/build)
-endif()
+# Location of the FFT library
+include_directories(${FIBER_FFT_INCLUDE_DIR})
+link_directories(${FIBER_FFT_LIB_DIR})
 
-if (FIBER_ENABLE_FFTMPI)
-add_definitions(-DFIBER_ENABLE_FFTMPI)
-include_directories($ENV{HOME}/Benchmarks_FFT/fftmpi/src)
-link_directories($ENV{HOME}/Benchmarks_FFT/fftmpi/src)
-endif()
+# Location of FFTW
+include_directories(${FFTW_DIR}/include)
+link_directories(${FFTW_DIR}/lib)
 
-if (FIBER_ENABLE_ACCFFT)
-add_definitions(-DFIBER_ENABLE_ACCFFT)
-include_directories($ENV{HOME}/Benchmarks_FFT/accfft/build/include)
-link_directories($ENV{HOME}/Benchmarks_FFT/accfft/build)
-endif()
+# Location of harness headers
+include_directories(include)
 
-if (FIBER_ENABLE_P3DFFT)
-add_definitions(-DFIBER_ENABLE_P3DFFT)
-include_directories($ENV{HOME}/Benchmarks_FFT/p3dfft/include)
-link_directories($ENV{HOME}/Benchmarks_FFT/p3dfft/build)
-endif()
-
-if (FIBER_ENABLE_FFTE)
-add_definitions(-DFIBER_ENABLE_FFTE)
-include_directories($ENV{HOME}/Benchmarks_FFT/ffte-7.0/include)
-link_directories($ENV{HOME}/Benchmarks_FFT/ffte-7.0/src)
-endif()
-
-if (FIBER_ENABLE_SWFFT)
-add_definitions(-DFIBER_ENABLE_SWFFT)
-include_directories($ENV{HOME}/Benchmarks_FFT/SWFFT/)
-link_directories($ENV{HOME}/Benchmarks_FFT/SWFFT/build)
-endif()
-
-if (FIBER_ENABLE_2DECOMP)
-add_definitions(-DFIBER_ENABLE_2DECOMP)
-include_directories($ENV{HOME}/Benchmarks_FFT/2decomp_fft/src)
-link_directories($ENV{HOME}/Benchmarks_FFT/2decomp_fft/build)
-endif()
-
-if (FIBER_ENABLE_NB3DFFT)
-add_definitions(-DFIBER_ENABLE_NB3DFFT)
-include_directories($ENV{HOME}/Benchmarks_FFT/nb3dfft/src)
-link_directories($ENV{HOME}/Benchmarks_FFT/nb3dfft/src)
-endif()
-
-include_directories(/sw/spack/2021-02-12/opt/spack/linux-scientific7-x86_64/gcc-7.3.0/fftw-3.3.9-xvbumufiowb3nqnifdffjdqga4gqsz2l/include)
-include_directories($ENV{HOME}/fiber/include)
-include_directories(/sw/openmpi/4.0.0/include)
-
-link_directories(/sw/spack/2021-02-12/opt/spack/linux-scientific7-x86_64/gcc-7.3.0/fftw-3.3.9-xvbumufiowb3nqnifdffjdqga4gqsz2l/lib)
-link_directories(/sw/openmpi/4.0.0/lib)
+# Location of MPI
+include_directories(${MPI_DIR}/include)
+link_directories(${MPI_DIR}/lib)
 
 if (FIBER_ENABLE_CUDA)
     find_package(CUDA REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,38 @@ else ()
     set ( CMAKE_C_STANDARD 99 )
 endif ()
 
+if (FIBER_ENABLE_HEFFTE)
+add_definitions(-DFIBER_ENABLE_HEFFTE)
+endif()
+
+if (FIBER_ENABLE_FFTMPI)
+add_definitions(-DFIBER_ENABLE_FFTMPI)
+endif()
+
+if (FIBER_ENABLE_ACCFFT)
+add_definitions(-DFIBER_ENABLE_ACCFFT)
+endif()
+
+if (FIBER_ENABLE_P3DFFT)
+add_definitions(-DFIBER_ENABLE_P3DFFT)
+endif()
+
+if (FIBER_ENABLE_FFTE)
+add_definitions(-DFIBER_ENABLE_FFTE)
+endif()
+
+if (FIBER_ENABLE_SWFFT)
+add_definitions(-DFIBER_ENABLE_SWFFT)
+endif()
+
+if (FIBER_ENABLE_2DECOMP)
+add_definitions(-DFIBER_ENABLE_2DECOMP)
+endif()
+
+if (FIBER_ENABLE_NB3DFFT)
+add_definitions(-DFIBER_ENABLE_NB3DFFT)
+endif()
+
 find_package(MPI REQUIRED)
 
 # Location of the FFT library
@@ -41,8 +73,6 @@ include_directories(include)
 # Location of MPI
 include_directories(${MPI_DIR}/include)
 link_directories(${MPI_DIR}/lib)
-
-add_definitions(-DFIBER_ENABLE_HEFFTE)
 
 if (FIBER_ENABLE_CUDA)
     find_package(CUDA REQUIRED)


### PR DESCRIPTION
Three majors changes to the cmake config:

1. Generalized the specification of FFT library include and library file location.  This removes the assumption that the library is installed in the user's home directory.  Instead, the user should specify the locations using `cmake -DFIBER_FFT_INCLUDE_DIR=... -DFIBER_FFT_LIB_DIR=.. ..`.
2. Removed the `add_definitions(...)` as this seems to be unnecessary.
3. Enables the specification of the install location of FFTW and MPI using $FFTW_DIR and $MPI_DIR instead of hard-coding paths.
4. Provides the harness with the location of its own include directory since it was otherwise unable to find it unless it was located in a hard-coded directory in the $HOME.

These changes allow the code to be compiled in any location without assumptions of the location of the harness or its dependencies.  These changes are necessary for easy integration into spack.