### PR TITLE
Added spack package file

### DIFF
--- a/spack/README
+++ b/spack/README
@@ -1,0 +1,8 @@
+This is a spack repository for the fiber spack package.
+
+To use this package in your spack install, run:
+
+```
+spack repo add $DIR/fiber/spack/
+```
+

--- a/spack/packages/fiber/package.py
+++ b/spack/packages/fiber/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from spack import *
+
+FFT_LIBS = (
+    'heffte',
+    'fftw',
+    'ffte',
+)
+
+
+class Fiber(CMakePackage):
+    """High Performance Fast Fourier Transform benchmark."""
+
+    homepage = "https://fiber.icl.utk.edu/"
+    git      = "https://github.com/icl-utk-edu/fiber"
+
+    maintainers = ['G-Ragghianti', 'luszczek']
+
+    version('master', branch='master')
+
+    variant('fft', default='none', values=FFT_LIBS,
+            multi=True, description='Supported FFT libraries')
+    #variant('onlycomplex', default=False)
+
+    depends_on('mpi')
+
+    # Iterate over the fftlib variant for simple dependencies
+    for fft in FFT_LIBS:
+        depends_on(fft, when='fft={0}'.format(fft))
+
+    depends_on('heffte+fftw+cuda', when='fft=heffte')
+
+    def cmake_args(self):
+        args = []
+        for fft in self.spec.variants['fft'].value:
+            args.extend(["-DFIBER_ENABLE_{0}=ON".format(fft.upper())])
+            # These don't seem to be required within spack 
+            #args.extend("-DFIBER_FFT_INCLUDE_DIRS={0}".format(self.spec[fft].prefix.include))
+            #args.extend("-DFIBER_FFT_LIB_DIRS={0}".format(self.spec[fft].prefix.lib))
+        return args
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.lib)
+        mkdirp(prefix.bin)
+        # Copy the generated binaries to the installation prefix
+        with working_dir(os.path.join(self.build_directory, 'benchmarks')):
+            install('../libfiber.so', prefix.lib)
+            for f in os.listdir('.'):
+                if os.path.isfile(f) and os.access(f, os.X_OK):
+                    install(f, prefix.bin)

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: icl.fiber


### PR DESCRIPTION
This is the package file that will be used to install fiber within spack.  It is good to have this in the same repo as the main code so that the spack package can be updated in sync with the code base.   The package.py is base don Piotr's previous work, but after working on it for a while I realized that the fft library would be better represented as a multi-value variant instead of separate variants for each library.  One reason this is better is that it allows us to easily iterate over the list of supported libraries to reduce redundant configs in the package definition.  