### PR TITLE
Change the prototype of the init function and add a finalize routine for each backend

### DIFF
--- a/benchmarks/test3D_C2C.c
+++ b/benchmarks/test3D_C2C.c
@@ -116,7 +116,13 @@ int main(int argc, char** argv){
     
     // Initialize Library
     int init_option = 1; // 
-    if(fiber_initialize[my_backend].function(init_option) == 0){
+    // The variable is used in the 2decomp&FFT library which may not be linked.
+    // So we hard code the value that must similar to the one in the library itself:
+    // PHYSICAL_IN_X = 0
+    // PHYSICAL_IN_Z = 1
+    // See decomp_2d_iface.h
+    int physical_direction = 0;
+    if(fiber_initialize[my_backend].function(physical_direction, nx, ny, nz, proc_grid[0], proc_grid[1]) == 0){ 
         if(me==0)
             printf("[%s] successfully initialized.\n", lib_name);
     }
@@ -181,6 +187,15 @@ int main(int argc, char** argv){
     // Data deallocation 
     free(input);
     free(output);
+
+    if(fiber_finalize[my_backend].function() == 0){ 
+        if(me==0)
+            printf("[%s] successfully finalized.\n", lib_name);
+    }
+    else {
+        if(me==0)
+            printf("[%s] failed to finalize.\n", lib_name);
+    }
 
     MPI_Finalize();
 

--- a/benchmarks/test3D_CPU_C2C.c
+++ b/benchmarks/test3D_CPU_C2C.c
@@ -76,6 +76,19 @@ int main(int argc, char** argv){
     int backend_options[20];
     backend_options[0] = 0; // forward/backward flag
     backend_options[4] = 1; // 1-D FFT backend
+
+    // The variable is used in the 2decomp&FFT library which may not be linked.
+    // So we hard code the value that must similar to the one in the library itself:
+    // PHYSICAL_IN_X = 0
+    // PHYSICAL_IN_Z = 1
+    // See decomp_2d_iface.h
+    int physical_direction = 0;
+    int p_row     = 1;
+    int p_col     = 2;
+    int nx        = box_high[0] - box_low[0] + 1;
+    int ny        = box_high[1] - box_low[1] + 1;
+    int nz        = box_high[2] - box_low[2] + 1;
+    fiber_initialize[my_backend].function(physical_direction, nx, ny, nz, p_row, p_col);
     
     // ********************************
     // Compute forward (Z2Z) transform
@@ -155,6 +168,9 @@ int main(int argc, char** argv){
 
     // Print errors
     printf("%s: rank [%d] computed error |X - ifft(fft(X)) |_{max}: %1.6le\n", backends[my_backend], me, err);
+
+    // finalization of the backend                                               
+    fiber_finalize[my_backend].function();
 
     // Data deallocation 
     free(input);

--- a/include/fiber_backend_accfft.h
+++ b/include/fiber_backend_accfft.h
@@ -12,7 +12,11 @@
 
 
 //=================== Initialization (if required) ============================
-int init_accfft(int option){
+int init_accfft(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_accfft(){
     return(0);
 }
 
@@ -133,7 +137,10 @@ void compute_z2d_accfft( int const inbox_low[3], int const inbox_high[3],
 }
 
 #else
-int init_accfft(int option)
+int init_accfft(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_accfft()
 {}
 
 void compute_z2z_accfft( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_decomp2d.h
+++ b/include/fiber_backend_decomp2d.h
@@ -12,7 +12,11 @@
 #include <decomp_2d.h>
 
 //=================== Initialization (if required) ============================
-int init_decomp2d(int option){
+int init_decomp2d(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_decomp2d(){
     return(0);
 }
 
@@ -103,7 +107,10 @@ void compute_z2d_decomp2d( int const inbox_low[3], int const inbox_high[3],
 
 
 #else
-int init_decomp2d(int option)
+int init_decomp2d(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_decomp2d()
 {}
 
 void compute_z2z_decomp2d( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_fftadvmpi.h
+++ b/include/fiber_backend_fftadvmpi.h
@@ -16,7 +16,11 @@
 #include <complex.h>
 
 //=================== Initialization (if required) ============================
-int init_fftadvmpi(int option){
+int init_fftadvmpi(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_fftadvmpi(){
     return(0);
 }
 
@@ -223,7 +227,10 @@ void compute_z2d_fftadvmpi( int const inbox_low[3], int const inbox_high[3],
 
 
 #else
-int init_fftadvmpi(int option)
+int init_fftadvmpi(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_fftadvmpi()
 {}
 
 void compute_z2z_fftadvmpi( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_ffte.h
+++ b/include/fiber_backend_ffte.h
@@ -11,7 +11,11 @@
 #if defined(FIBER_ENABLE_FFTE)
 
 //=================== Initialization (if required) ============================
-int init_ffte(int option){
+int init_ffte(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_ffte(){
     return(0);
 }
 
@@ -140,7 +144,10 @@ void compute_z2d_ffte(int const inbox_low[3], int const inbox_high[3],
 }
 
 #else 
-int init_ffte(int option)
+int init_ffte(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_ffte()
 {}
 
 void compute_z2z_ffte(int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_fftmpi.h
+++ b/include/fiber_backend_fftmpi.h
@@ -14,7 +14,11 @@
 
 
 //=================== Initialization (if required) ============================
-int init_fftmpi(int option){
+int init_fftmpi(int nx, int ny, int nz, int p_row, int p_col, int physical){
+    return(0);
+}
+
+int finalize_fftmpi(){
     return(0);
 }
 
@@ -118,7 +122,10 @@ void compute_z2d_fftmpi( int const inbox_low[3], int const inbox_high[3],
 }
 
 #else
-int init_fftmpi(int option)
+int init_fftmpi(int nx, int ny, int nz, int p_row, int p_col, int physical)
+{}
+
+int finalize_fftmpi()
 {}
 
 void compute_z2z_fftmpi( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_fftw.h
+++ b/include/fiber_backend_fftw.h
@@ -31,8 +31,12 @@
  */
 
 //=================== Initialization (if required) ============================
-int init_fftw(int option){
+int init_fftw(int physical, int nx, int ny, int nz, int p_row, int p_col){
     fftw_mpi_init();
+    return(0);
+}
+
+int finalize_fftw(){
     return(0);
 }
 
@@ -184,10 +188,11 @@ void compute_z2d_fftw( int const inbox_low[3], int const inbox_high[3],
 
 #else
 
-int init_fftw(int option)
-{
-    return(0);
-}
+int init_fftw(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_fftw()
+{}
 
 
 void compute_z2z_fftw( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_fftwpp.h
+++ b/include/fiber_backend_fftwpp.h
@@ -26,10 +26,14 @@
  */
 
 //=================== Initialization (if required) ============================
-int init_fftwpp(int option){
+int init_fftwpp(int physical, int nx, int ny, int nz, int p_row, int p_col){
 
     unsigned int nthreads = 1;
     set_fftwpp_maxthreads(nthreads);
+    return(0);
+}
+
+int finalize_fftwpp(){
     return(0);
 }
 
@@ -124,10 +128,11 @@ void compute_z2d_fftwpp( int const inbox_low[3], int const inbox_high[3],
 
 #else
 
-int init_fftwpp(int option)
-{
-    return(0);
-}
+int init_fftwpp(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_fftwpp()
+{}
 
 
 void compute_z2z_fftwpp( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_heffte.h
+++ b/include/fiber_backend_heffte.h
@@ -14,7 +14,11 @@
 #include "heffte.h"
 
 //=================== Initialization (if required) ============================
-int init_heffte(int option){
+int init_heffte(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_heffte(){
     return(0);
 }
 
@@ -192,7 +196,10 @@ void compute_z2d_heffte( int const inbox_low[3], int const inbox_high[3],
 // ========================================================================================
 
 #else
-int init_heffte(int option)
+int init_heffte(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
+
+int finalize_heffte()
 {}
 
 void compute_z2z_heffte( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_nb3dfft.h
+++ b/include/fiber_backend_nb3dfft.h
@@ -12,7 +12,11 @@
 #if defined(FIBER_ENABLE_NB3DFFT)
 
 //=================== Initialization (if required) ============================
-int init_nb3dfft(int option){
+int init_nb3dfft(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_nb3dfft(){
     return(0);
 }
 
@@ -78,8 +82,10 @@ void compute_z2d_nb3dfft( int const inbox_low[3], int const inbox_high[3],
 }
 
 #else
+int init_nb3dfft(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
 
-int init_nb3dfft(int option)
+int finalize_nb3dfft()
 {}
 
 void compute_z2z_nb3dfft( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_p3dfft.h
+++ b/include/fiber_backend_p3dfft.h
@@ -12,7 +12,11 @@
 #include "p3dfft.h"
 
 //=================== Initialization (if required) ============================
-int init_p3dfft(int option){
+int init_p3dfft(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_p3dfft(){
     return(0);
 }
 
@@ -237,8 +241,10 @@ void compute_z2d_p3dfft( int const inbox_low[3], int const inbox_high[3],
 }
 
 #else
+int init_p3dfft(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
 
-int init_p3dfft(int option)
+int finalize_p3dfft()
 {}
 
 void compute_z2z_p3dfft( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backend_swfft.h
+++ b/include/fiber_backend_swfft.h
@@ -12,7 +12,11 @@
 #include "swfft.h"
 
 //=================== Initialization (if required) ============================
-int init_swfft(int option){
+int init_swfft(int physical, int nx, int ny, int nz, int p_row, int p_col){
+    return(0);
+}
+
+int finalize_swfft(){
     return(0);
 }
 
@@ -80,8 +84,10 @@ void compute_z2d_swfft( int const inbox_low[3], int const inbox_high[3],
 }
 
 #else
+int init_swfft(int physical, int nx, int ny, int nz, int p_row, int p_col)
+{}
 
-int init_swfft(int option)
+int finalize_swfft()
 {}
 
 void compute_z2z_swfft( int const inbox_low[3], int const inbox_high[3],

--- a/include/fiber_backends.h
+++ b/include/fiber_backends.h
@@ -18,7 +18,7 @@
 
 // Available backends
 char backends[][20] = {"heFFTe", "FFTMPI", "AccFFT", "P3DFFT", "FFTE", "SWFFT", "2DECOMP&FFT", "nb3dFFT", "FFTW", "fftadvmpi", "FFTW++"};
-int n_backends = 10;
+int n_backends = 11;
 
 enum backend{heffte, fftmpi, accfft, p3dfft, ffte, swfft, decomp2d, nb3dfft, fftw, fftadvmpi, fftwpp};
 
@@ -26,7 +26,7 @@ enum backend{heffte, fftmpi, accfft, p3dfft, ffte, swfft, decomp2d, nb3dfft, fft
 struct fiber_init
 {
     char *name;
-    int (*function)( int );
+    int (*function)( int, int, int, int, int, int );
 };
 
 const struct fiber_init fiber_initialize[] = {
@@ -42,6 +42,27 @@ const struct fiber_init fiber_initialize[] = {
     { "fftadvmpi",  &init_fftadvmpi },
     { "fftwpp",     &init_fftwpp }
 };
+
+// Backends finalization
+struct fiber_finalize
+{
+    char *name;
+    int (*function)( void );
+};
+//*
+const struct fiber_finalize fiber_finalize[] = {
+    { "heffte",     &finalize_heffte    },
+    { "fftmpi",     &finalize_fftmpi    },
+    { "accfft",     &finalize_accfft    },
+    { "p3dfft",     &finalize_p3dfft    },
+    { "ffte",       &finalize_ffte      },
+    { "swfft",      &finalize_swfft     },
+    { "decomp2d",   &finalize_decomp2d  },
+    { "nb3dfft",    &finalize_nb3dfft   },
+    { "fftw",       &finalize_fftw      },
+    { "fftadvmpi",  &finalize_fftadvmpi },
+    { "fftw",       &finalize_fftwpp }
+};//*/
 
 // Real-to-complex transform
 struct fiber_map_backend_d2z


### PR DESCRIPTION
## Problem

The interface for the init routine takes only one parameter whereas 2decomp&FFT needs more.
Also, there is no finalize routine.

## Proposed solution

In this PR, we propose to change the prototype of the init routine to take at least the parameters needed for 2decomp&FFT.
It does not impact the other backends.
We add a finalize routine and integrate it into all backends.
We also update some tests drivers accordingly.

### Side note
This PR also fixes the number of backends.