### PR TITLE
Seb/add 2decomp iface CMakeLists

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extra/2decompFFT_c_iface"]
-	path = external/2decompFFT_c_iface
-	url = https://github.com/cayrols/2decompFFT_c_iface.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ endif()
 
 if (FIBER_ENABLE_2DECOMP)
     add_definitions(-DFIBER_ENABLE_2DECOMP)
+    add_subdirectory(external/2decompFFT_c_iface)
+    include_directories(PUBLIC ${CMAKE_BINARY_DIR}/external/2decompFFT_c_iface)
+    link_directories(${CMAKE_BINARY_DIR}/external/2decompFFT_c_iface)
 endif()
 
 if (FIBER_ENABLE_NB3DFFT)

--- a/external/2decompFFT_c_iface/CMakeLists.txt
+++ b/external/2decompFFT_c_iface/CMakeLists.txt
@@ -16,13 +16,19 @@ message( STATUS "FFTW path: ${FFTW_PATH}" )
 
 # TODO use findpackage if possible
 if (NOT DEFINED ENV{DECOMPFFT_ROOT})
-  message( FATAL_ERROR "Cannot find DECOMPFFT_ROOT in the env" )
+  if (NOT DEFINED DECOMPFFT_ROOT)
+    message( FATAL_ERROR 
+      "DECOMPFFT_ROOT cannot be found but is required."
+      " Please provide it through env or by defining it -DDECOMPFFT_ROOT." )
+  endif ()
 endif ()
 
 set( DECOMPFFT_ROOT $ENV{DECOMPFFT_ROOT} )
+message( STATUS "2DECOMP&FFT root: ${DECOMPFFT_ROOT}" )
+
+# Define paths where the library and the header will be located
 set( DECOMPFFT_IFACE_LIB ${CMAKE_CURRENT_BINARY_DIR} )
 set( DECOMPFFT_IFACE_INC ${CMAKE_CURRENT_BINARY_DIR} )
-message( STATUS "2DECOMP&FFT root: ${DECOMPFFT_ROOT}" )
 message( STATUS "2DECOMP&FFT interface lib: ${DECOMPFFT_IFACE_LIB}" )
 message( STATUS "2DECOMP&FFT interface include: ${DECOMPFFT_IFACE_INC}" )
 
@@ -33,6 +39,6 @@ ExternalProject_Add(
     GIT_REPOSITORY https://github.com/cayrols/2decompFFT_c_iface.git 
     GIT_TAG master
     CONFIGURE_COMMAND cd <SOURCE_DIR> && cp make.inc.example make.inc
-    BUILD_COMMAND make -C <SOURCE_DIR> lib
-    INSTALL_COMMAND make -C <SOURCE_DIR> DECOMP_LIB=${DECOMPFFT_IFACE_LIB} DECOMP_INC=${DECOMPFFT_IFACE_INC} install
+    BUILD_COMMAND make -C <SOURCE_DIR> DECOMP_ROOT=${DECOMPFFT_ROOT} lib
+    INSTALL_COMMAND make -C <SOURCE_DIR> DECOMP_ROOT=${DECOMPFFT_ROOT} DECOMP_LIB=${DECOMPFFT_IFACE_LIB} DECOMP_INC=${DECOMPFFT_IFACE_INC} install
 )

--- a/external/2decompFFT_c_iface/CMakeLists.txt
+++ b/external/2decompFFT_c_iface/CMakeLists.txt
@@ -1,0 +1,38 @@
+project(install_2decomp_iface)
+
+cmake_minimum_required(VERSION 3.22)
+
+include(ExternalProject)
+
+# FFTW has to be set in the env for 2decomp Makefile.inc to work properly
+if (NOT ENV{FFTW_PATH})
+  if (NOT DEFINED FFTW_PATH)
+    message( FATAL_ERROR 
+      "FFTW_PATH cannot be found but is required for 2decomp src/Makefile.inc file."
+      " Please provide it through env or by defining it -DFFTW_PATH." )
+  endif ()
+endif ()
+message( STATUS "FFTW path: ${FFTW_PATH}" )
+
+# TODO use findpackage if possible
+if (NOT DEFINED ENV{DECOMPFFT_ROOT})
+  message( FATAL_ERROR "Cannot find DECOMPFFT_ROOT in the env" )
+endif ()
+
+set( DECOMPFFT_ROOT $ENV{DECOMPFFT_ROOT} )
+set( DECOMPFFT_IFACE_LIB ${CMAKE_CURRENT_BINARY_DIR} )
+set( DECOMPFFT_IFACE_INC ${CMAKE_CURRENT_BINARY_DIR} )
+message( STATUS "2DECOMP&FFT root: ${DECOMPFFT_ROOT}" )
+message( STATUS "2DECOMP&FFT interface lib: ${DECOMPFFT_IFACE_LIB}" )
+message( STATUS "2DECOMP&FFT interface include: ${DECOMPFFT_IFACE_INC}" )
+
+ExternalProject_Add(
+    2decomp_c_iface 
+    PREFIX ../internal_cmake_dl_files
+    SOURCE_DIR 2decomp_fft_build
+    GIT_REPOSITORY https://github.com/cayrols/2decompFFT_c_iface.git 
+    GIT_TAG master
+    CONFIGURE_COMMAND cd <SOURCE_DIR> && cp make.inc.example make.inc
+    BUILD_COMMAND make -C <SOURCE_DIR> lib
+    INSTALL_COMMAND make -C <SOURCE_DIR> DECOMP_LIB=${DECOMPFFT_IFACE_LIB} DECOMP_INC=${DECOMPFFT_IFACE_INC} install
+)

--- a/external/README.md
+++ b/external/README.md
@@ -21,4 +21,21 @@ AccFFT
 2DECOMP&FFT
 ============
 
-The [2DECOMP&FFT](http://www.2decomp.org/) library is written in Fortran and no longer being maintained. Creating a C-interface requires some extra work, which we elaborate in [2Decomp C-Interface](https://github.com/cayrols/2decompFFT_c_iface/tree/3957f639890c2e9a8113d27b49c5cf75eb060d95).
+The [2DECOMP&FFT](http://www.2decomp.org/) library is written in Fortran and no longer being maintained. 
+Creating a C-interface requires some extra work, which we elaborate in [2Decomp C-Interface](https://github.com/cayrols/2decompFFT_c_iface/tree/3957f639890c2e9a8113d27b49c5cf75eb060d95).
+
+### Create the interface
+
+The following will automatically download the interface source files and build the corresponding library.
+
+To compile the interface, we need to have `FFTW_PATH` and `DECOMPFFT_ROOT` env variables set.
+One example to create the interface is:
+```
+mkdir <build_folder>
+cmake -DFFTW_PATH=<path_to_fftw_root> <path_to_CMakeLists.txt>
+make 
+```
+
+The created library `lib2decomp_fft_iface.a` and the include file `decomp_2d_iface.h` will be located in the `<build_folder>`.
+
+Note: the interface uses the file `src/Makefile.inc` of the 2decomp&FFT library, which itself needs the path to FFTW through `FFTW_PATH`.


### PR DESCRIPTION
This Pull Request addresses the creation of the 2decomp&FFT library interface.

We create a CMakeLists.txt file, that downloads the source and compiles the library.
The created library and the header file will be located in the build folder. 

Note: We remove 2decomp as a submodule.